### PR TITLE
add wazo-debug dependency

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -43,6 +43,7 @@ Depends:
     wazo-confgend,
     wazo-confgend-client,
     wazo-consul-config,
+    wazo-debug,
     wazo-dird,
     wazo-dist-upgrade,
     wazo-dxtora,


### PR DESCRIPTION
reason: to avoid to tell people to install this package before executing
command