### PR TITLE
do not use transitional package for python-certbot-nginx

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -20,7 +20,7 @@ Depends:
     mutt,
     ntp,
     postfix,
-    python-certbot-nginx,
+    python3-certbot-nginx,
     rabbitmq-server,
     rsync,
     screen,


### PR DESCRIPTION
why: python-certbot-nginx will install python3-certbot-nginx ...
moreover python-certbot-nginx doesn't exist in Bullseye